### PR TITLE
Enable logging if log_dir is configured

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -12,7 +12,7 @@ function logger(config) {
   var bunyan_options = {}
     , log_dir
 
-  if(!config.verbose && !config.log) {
+  if(!config.verbose && !config.log && !config.log_dir) {
     return noop_logger
   }
 
@@ -23,7 +23,7 @@ function logger(config) {
     bunyan_options.streams.push({level: 'info', stream: process.stdout})
   }
 
-  if(config.log) {
+  if(config.log || config.log_dir) {
     log_dir = config.log_dir || process.cwd()
 
     bunyan_options.streams.push({


### PR DESCRIPTION
Discussed earlier: if `log_dir` is configured, assume logging is desired.
