### PR TITLE
remove breaking, unused var

### DIFF
--- a/lib/models/Package/index.js
+++ b/lib/models/Package/index.js
@@ -104,8 +104,7 @@ function save_meta(name, version, tags, meta, done) {
 }
 
 function add(name, version, tags, meta, tarball, done) {
-  var config = context().config
-    , req
+  var req
 
   try {
     req = request(tarball)


### PR DESCRIPTION
this isn't used anywhere and causes an error
