### PR TITLE
Store the base dir. Used to load modules relative to the root. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ function unpm(ns, config) {
   self.config = config
   self.middleware = []
   self.backend = Object.create(config.backend)
+  self.dir = __dirname
   auth(self)
   cidr(self)
 


### PR DESCRIPTION
This can be leveraged to load modules in the root/node_modules directory. See
- https://github.com/ryanramage/unpm-auth-ldap
- https://github.com/ryanramage/unpm-auth/commit/39373949c19be453d1ac211ad6c7f05868a88675

For usage.
