### PR TITLE
Fix method of determining latest version

### DIFF
--- a/lib/models/Package.js
+++ b/lib/models/Package.js
@@ -1,4 +1,5 @@
 var guard = require('../utils/guard')
+var latest_version = require('../utils/latest-version')
 var semver = require('semver')
 
 var methods = [
@@ -101,7 +102,7 @@ function removeVersion(name, version, done) {
 
     delete meta.versions[version]
 
-    meta['dist-tags'].latest = Object.keys(meta.versions).sort(semver.lt)[0]
+    meta['dist-tags'].latest = latest_version(Object.keys(meta.versions))
 
     if(Object.keys(meta.versions).length) {
       self._setMeta(name, meta, removeTarball)
@@ -200,8 +201,7 @@ function saveMeta(name, version, tags, meta, done) {
     module_meta.versions[version] = meta.versions[version]
     versions.push(version)
 
-    versions.sort(semver.lt)
-    module_meta['dist-tags'].latest = versions[0]
+    module_meta['dist-tags'].latest = latest_version(versions)
 
     Object.keys(tags).forEach(function(tag) {
       if(!module_meta['dist-tags'][tag]) {

--- a/lib/utils/latest-version.js
+++ b/lib/utils/latest-version.js
@@ -1,0 +1,15 @@
+var semver = require('semver')
+
+module.exports = latest_version
+
+function latest_version(versions) {
+  return versions.sort(by_semver)[0]
+}
+
+function by_semver(v1, v2) {
+  if(semver.lt(v1, v2)) {
+    return 1
+  }
+
+  return -1
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
+var latest_version = require('./utils/latest-version.test')
 var Package = require('./models/Package.test')
 var middleware = require('./middleware.test')
 var integration = require('./integration')

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,7 +1,7 @@
+var latest_version = require('../../lib/utils/latest-version')
 var backend = require('unpm-mem-backend')
 var unpm = require('../../index')
 var request = require('request')
-var semver = require('semver')
 var test = require('tape')
 var url = require('url')
 var fs = require('fs')
@@ -120,7 +120,7 @@ function verify(config, t) {
   }
 
   function bumpVersionAndPut(done) {
-    var latest = Object.keys(fixture.versions).sort(semver.lt)[0]
+    var latest = latest_version(Object.keys(fixture.versions))
 
     var new_version = latest.split('.')
 

--- a/test/utils/latest-version.test.js
+++ b/test/utils/latest-version.test.js
@@ -1,0 +1,19 @@
+var test = require('tape')
+var latest_version = require('../../lib/utils/latest-version')
+
+test('returns latest version by semver in array', function(t) {
+  t.equal(
+      latest_version(['1.1.1', '1.5.1', '1.5.2', '1.0.1', '0.1.2'])
+    , '1.5.2'
+  )
+
+  t.equal(
+      latest_version(['0.1.1', '0.5.1', '1.5.2', '1.5.1', '1.4.2'])
+    , '1.5.2'
+  )
+
+  t.equal(latest_version(['0.1.1']) , '0.1.1')
+  t.equal(latest_version(['0.1.1', '0.1.90']) , '0.1.90')
+
+  t.end()
+})


### PR DESCRIPTION
`semver.lt` actually just returns a boolean indicating if the first arg is less than the second, so using it as the sorting function was faulty.