### PR TITLE
bump range_check, add LTS to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js:
-  #- "0.11"
+  - "4.4"
+  - "4.3"
+  - "4.2"
+  - "4.1"
+  - "4.0"
   - "0.10"
 after_script: npm run coveralls

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "concat-stream": "^1.4.6",
     "mkdirp": "^0.3.5",
     "nopt": "^2.2.1",
-    "range_check": "0.0.4",
+    "range_check": "1.2.0",
     "request": "^2.34.0",
     "semver": "^2.3.2",
     "unpm-auth": "^1.0.2",


### PR DESCRIPTION
This version of `range_check` is ancient, and relying on a similarly-ancient version of `ipaddr.js` that doesn't work on modern node. This upgrades them to their newer versions as well as adds the LTS node versions to the travis config.