### PR TITLE
Enable gzip with request

### DIFF
--- a/lib/controllers/getPackage.js
+++ b/lib/controllers/getPackage.js
@@ -58,7 +58,10 @@ function getPackage(respond, route, unpm) {
 
     if(fallback[fallback.length - 1] === '/') fallback = fallback.slice(0, -1)
 
-    request(fallback + route.path, proxyResponse)
+    request({
+      uri: fallback + route.path,
+      gzip: true
+    }, proxyResponse)
   }
 
   function proxyResponse(err, res, data) {
@@ -80,7 +83,10 @@ function getPackage(respond, route, unpm) {
   }
 
   function addFallback(meta) {
-    request(unpm.config.fallback + route.path, function onResponse(err, res, data) {
+    request({
+      uri: unpm.config.fallback + route.path,
+      gzip: true
+    }, function onResponse(err, res, data) {
       var versions
       if(err || res.statusCode !== 200) {
         return respond(null, 200, meta)


### PR DESCRIPTION
It fixes the exceptions like:

```
Unexpected token \u001f
  at Object.parse (native)
  at Request.proxyResponse [as _callback] (node_modules/unpm/lib/controllers/getPackage.js:76:32)
  at Request.self.callback (node_modules/request/request.js:199:22)
  at emitTwo (events.js:100:13)
  at Request.emit (events.js:185:7)
  at Request.<anonymous> (node_modules/request/request.js:1036:10)
  at emitOne (events.js:95:20)
  at Request.emit (events.js:182:7)
  at IncomingMessage.<anonymous> (node_modules/request/request.js:963:12)
  at emitNone (events.js:85:20)
```

It happens with some packages from the official npm repository.