### PR TITLE
Allow synchronous and asynchronous reading of tarballs from arbitrary sources

### DIFF
--- a/lib/controllers/getTarball.js
+++ b/lib/controllers/getTarball.js
@@ -4,24 +4,12 @@ function getTarball(respond, route, unpm) {
   var version = route.params.version
   var name = route.params.name
   var started = false
-  var getTarballAsync = unpm.Package.getTarballAsync
-  var getTarballSync = unpm.Package.getTarball
+  var getTarballStreamAsync = unpm.Package.getTarballAsync
+  var getTarballStreamSync = unpm.Package.getTarball
 
   var tarballStream = null
 
-  if (typeof getTarballSync === 'function') {
-    // Use synchronous behavior for fetching tarball. We're assuming it's coming from disk
-    tarballStream = getTarballSync(name, version)
-    doneFnc()
-  } else if (typeof getTarballAsync === 'function') {
-    // Async handler. Will provide a done function when the tarball is ready
-    getTarballAsync(name, version, function (tball) {
-      tarballStream = tball
-      doneFnc()
-    })
-  }
-
-  var doneFnc = function () {
+  function doneFnc() {
     tarballStream.on('error', function(err) {
       if(started) {
         return unpm.log.error(err)
@@ -42,5 +30,17 @@ function getTarball(respond, route, unpm) {
     function notFound() {
       return respond.notFound()
     }
+  }
+
+  if (typeof getTarballSync === 'function') {
+    // Use synchronous behavior for fetching tarball. We're assuming it's coming from disk
+    tarballStream = getTarballStreamSync(name, version)
+    process.nextTick(doneFnc)
+  } else if (typeof getTarballAsync === 'function') {
+    // Async handler. Will provide a done function when the tarball is ready
+    getTarballStreamAsync(name, version, function (tball) {
+      tarballStream = tball
+      process.nextTick(doneFnc)
+    })
   }
 }

--- a/lib/controllers/getTarball.js
+++ b/lib/controllers/getTarball.js
@@ -31,12 +31,11 @@ function getTarball(respond, route, unpm) {
       return respond.notFound()
     }
   }
-
-  if (typeof getTarballSync === 'function') {
+  if (typeof getTarballStreamSync === 'function') {
     // Use synchronous behavior for fetching tarball. We're assuming it's coming from disk
     tarballStream = getTarballStreamSync(name, version)
     process.nextTick(doneFnc)
-  } else if (typeof getTarballAsync === 'function') {
+  } else if (typeof getTarballStreamAsync === 'function') {
     // Async handler. Will provide a done function when the tarball is ready
     getTarballStreamAsync(name, version, function (tball) {
       tarballStream = tball

--- a/lib/controllers/getTarball.js
+++ b/lib/controllers/getTarball.js
@@ -13,7 +13,7 @@ function getTarball(respond, route, unpm) {
     // Use synchronous behavior for fetching tarball. We're assuming it's coming from disk
     tarballStream = getTarballSync(name, version)
     doneFnc()
-  } else if (typeof getTarball === 'function') {
+  } else if (typeof getTarballAsync === 'function') {
     // Async handler. Will provide a done function when the tarball is ready
     getTarballAsync(name, version, function (tball) {
       tarballStream = tball

--- a/lib/controllers/getTarball.js
+++ b/lib/controllers/getTarball.js
@@ -4,27 +4,43 @@ function getTarball(respond, route, unpm) {
   var version = route.params.version
   var name = route.params.name
   var started = false
+  var getTarballAsync = unpm.Package.getTarballAsync
+  var getTarballSync = unpm.Package.getTarball
 
-  var tarballStream = unpm.Package.getTarball(name, version)
+  var tarballStream = null
 
-  tarballStream.on('error', function(err) {
-    if(started) {
-      return unpm.log.error(err)
+  if (typeof getTarballSync === 'function') {
+    // Use synchronous behavior for fetching tarball. We're assuming it's coming from disk
+    tarballStream = getTarballSync(name, version)
+    doneFnc()
+  } else if (typeof getTarball === 'function') {
+    // Async handler. Will provide a done function when the tarball is ready
+    getTarballAsync(name, version, function (tball) {
+      tarballStream = tball
+      doneFnc()
+    })
+  }
+
+  var doneFnc = function () {
+    tarballStream.on('error', function(err) {
+      if(started) {
+        return unpm.log.error(err)
+      }
+
+      if(err.code === 'ENOTFOUND' || err.code === 'ENOENT' || err.notFound) {
+        return notFound()
+      }
+
+      respond.onError()
+    })
+
+    tarballStream.once('data', function(data) {
+      started = true
+      tarballStream.pipe(respond.res).write(data)
+    })
+
+    function notFound() {
+      return respond.notFound()
     }
-
-    if(err.code === 'ENOTFOUND' || err.code === 'ENOENT' || err.notFound) {
-      return notFound()
-    }
-
-    respond.onError()
-  })
-
-  tarballStream.once('data', function(data) {
-    started = true
-    tarballStream.pipe(respond.res).write(data)
-  })
-
-  function notFound() {
-    return respond.notFound()
   }
 }

--- a/lib/models/Package.js
+++ b/lib/models/Package.js
@@ -7,6 +7,7 @@ var methods = [
   'setMeta',
   'removeMeta',
   'getTarball',
+  'getTarballAsync',
   'setTarball',
   'removeTarball'
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unpm",
-  "version": "1.5.1",
+  "version": "1.5.0",
   "description": "private npm registry in node",
   "main": "./index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unpm",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "private npm registry in node",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
### Hi there! Please comment and criticize this PR :)

I have implemented an interface over `unpm` that makes it backed by AWS's S3, rather than a local file system. What this means is that reading tarballs happen asynchronously over network requests. My proposal is to simply allow a `getTarballAsync` method to be defined, rather than the default `getTarball`. This will allow for async fetches to occur. This also keeps the burden of returning a `ReadableStream` object back to `unpm` on the developer that's integrating a custom backend with `unpm`.

Thanks!